### PR TITLE
refactor: Rename value matcher classes to use suffix 'ValueMatcher'

### DIFF
--- a/bdikit/mapping_algorithms/value_mapping/algorithms.py
+++ b/bdikit/mapping_algorithms/value_mapping/algorithms.py
@@ -21,7 +21,7 @@ class ValueMatch(NamedTuple):
     similarity: float
 
 
-class BaseAlgorithm:
+class BaseValueMatcher:
     """
     Base class for value matching algorithms, i.e., algorithms that match
     values from a source (current) domain to values from a target domain.
@@ -33,7 +33,7 @@ class BaseAlgorithm:
         raise NotImplementedError("Subclasses must implement this method")
 
 
-class PolyFuzzAlgorithm(BaseAlgorithm):
+class PolyFuzzValueMatcher(BaseValueMatcher):
     """
     Base class for value matching algorithms based on the PolyFuzz library.
     """
@@ -63,7 +63,7 @@ class PolyFuzzAlgorithm(BaseAlgorithm):
         return matches
 
 
-class TFIDFAlgorithm(PolyFuzzAlgorithm):
+class TFIDFValueMatcher(PolyFuzzValueMatcher):
     """
     Value matching algorithm based on the TF-IDF similarity between values.
     """
@@ -72,7 +72,7 @@ class TFIDFAlgorithm(PolyFuzzAlgorithm):
         super().__init__(PolyFuzz(method=TFIDF(n_gram_range=(1, 3), min_similarity=0)))
 
 
-class EditAlgorithm(PolyFuzzAlgorithm):
+class EditDistanceValueMatcher(PolyFuzzValueMatcher):
     """
     Value matching algorithm based on the edit distance between values.
     """
@@ -89,7 +89,7 @@ class EditAlgorithm(PolyFuzzAlgorithm):
         )
 
 
-class EmbeddingAlgorithm(PolyFuzzAlgorithm):
+class EmbeddingValueMatcher(PolyFuzzValueMatcher):
     """
     Value matching algorithm based on the cosine similarity of value embeddings.
     """
@@ -100,7 +100,7 @@ class EmbeddingAlgorithm(PolyFuzzAlgorithm):
         super().__init__(PolyFuzz(method))
 
 
-class FastTextAlgorithm(PolyFuzzAlgorithm):
+class FastTextValueMatcher(PolyFuzzValueMatcher):
     """
     Value matching algorithm based on the cosine similarity of FastText embeddings.
     """
@@ -111,7 +111,7 @@ class FastTextAlgorithm(PolyFuzzAlgorithm):
         super().__init__(PolyFuzz(method))
 
 
-class LLMAlgorithm(BaseAlgorithm):
+class GPTValueMatcher(BaseValueMatcher):
     def __init__(self):
         self.client = OpenAI()
 
@@ -158,7 +158,7 @@ class LLMAlgorithm(BaseAlgorithm):
         return matches
 
 
-class AutoFuzzyJoinAlgorithm(BaseAlgorithm):
+class AutoFuzzyJoinValueMatcher(BaseValueMatcher):
 
     def __init__(self):
         pass

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -4,4 +4,4 @@ API
 
 .. automodule:: bdikit.api
     :members:
-    :exclude-members: SchemaMatchers, ValueMatchingMethod, ValueMatchingResult
+    :exclude-members: SchemaMatchers, ValueMatchers, ValueMatchingResult

--- a/tests/test_value_matching_algorithms.py
+++ b/tests/test_value_matching_algorithms.py
@@ -1,19 +1,19 @@
 import unittest
 import pandas as pd
 from bdikit.mapping_algorithms.value_mapping.algorithms import (
-    TFIDFAlgorithm,
-    EditAlgorithm,
+    TFIDFValueMatcher,
+    EditDistanceValueMatcher,
 )
 
 
-class ValueMatchingAlgorithmsTest(unittest.TestCase):
+class ValueMatchingTest(unittest.TestCase):
 
     def test_tfidf_value_matching(self):
         # given
         current_values = ["Red Apple", "Banana", "Oorange", "Strawberry"]
         target_values = ["apple", "banana", "orange", "kiwi"]
 
-        tfidf_matcher = TFIDFAlgorithm()
+        tfidf_matcher = TFIDFValueMatcher()
 
         # when
         matches = tfidf_matcher.match(current_values, target_values)
@@ -35,7 +35,7 @@ class ValueMatchingAlgorithmsTest(unittest.TestCase):
         current_values = ["Red Apple", "Banana", "Oorange", "Strawberry"]
         target_values = ["apple", "bananana", "orange", "kiwi"]
 
-        edit_distance_matcher = EditAlgorithm()
+        edit_distance_matcher = EditDistanceValueMatcher()
 
         # when
         matches = edit_distance_matcher.match(


### PR DESCRIPTION
This makes value matchers more consistent with other operations such as schema matching (SchemaMatcher's) and top-k column matching (TopkColumnMatcher).