### PR TITLE
refactor: Rename variables for better API naming consistency

### DIFF
--- a/bdikit/api.py
+++ b/bdikit/api.py
@@ -394,7 +394,7 @@ def _match_values(
         for source_value, target_value, similarity in matches_lowercase:
             matches.append(
                 ValueMatch(
-                    current_value=source_values_dict[source_value],
+                    source_value=source_values_dict[source_value],
                     target_value=target_values_dict[target_value],
                     similarity=similarity,
                 )
@@ -690,7 +690,7 @@ def create_mapper(
     - If input is a function (or lambda function), it creates a FunctionValueMapper object.
     - If input is a list of ValueMatch objects or tuples (<source_value>, <target_value>),
       it creates a DictionaryMapper object.
-    - If input is a DataFrame with two columns ("current_value", "target_value"),
+    - If input is a DataFrame with two columns ("source_value", "target_value"),
       it creates a DictionaryMapper object.
     - If input is a dictionary containing a "source" and "target" key, it tries to create
       a ValueMapper object based on the specification given in "mapper" or "matches" keys.
@@ -723,10 +723,10 @@ def create_mapper(
     # If the input is a DataFrame with two columns, we can create a
     # DictionaryMapper based on the values in the DataFrame
     if isinstance(input, pd.DataFrame) and all(
-        k in input.columns for k in ["current_value", "target_value"]
+        k in input.columns for k in ["source_value", "target_value"]
     ):
         return DictionaryMapper(
-            input.set_index("current_value")["target_value"].to_dict()
+            input.set_index("source_value")["target_value"].to_dict()
         )
 
     if isinstance(input, Dict):
@@ -767,7 +767,7 @@ def _create_mapper_from_value_matches(matches: List[ValueMatch]) -> DictionaryMa
     mapping_dict = {}
     for match in matches:
         if isinstance(match, ValueMatch):
-            mapping_dict[match.current_value] = match.target_value
+            mapping_dict[match.source_value] = match.target_value
         elif isinstance(match, tuple) and len(match) == 2:
             if isinstance(match[0], str) and isinstance(match[1], str):
                 mapping_dict[match[0]] = match[1]

--- a/bdikit/visualization/schema_matching.py
+++ b/bdikit/visualization/schema_matching.py
@@ -584,7 +584,7 @@ class BDISchemaMatchingHeatMap(TopkColumnMatcher):
         mapping = mappings[0]
         df = pd.DataFrame(
             {
-                "Source Value": [match.current_value for match in mapping["matches"]],
+                "Source Value": [match.source_value for match in mapping["matches"]],
                 "Target Value": [match.target_value for match in mapping["matches"]],
                 "Similarity": [match.similarity for match in mapping["matches"]],
             }

--- a/tests/test_value_matching_algorithms.py
+++ b/tests/test_value_matching_algorithms.py
@@ -10,13 +10,13 @@ class ValueMatchingTest(unittest.TestCase):
 
     def test_tfidf_value_matching(self):
         # given
-        current_values = ["Red Apple", "Banana", "Oorange", "Strawberry"]
+        source_values = ["Red Apple", "Banana", "Oorange", "Strawberry"]
         target_values = ["apple", "banana", "orange", "kiwi"]
 
         tfidf_matcher = TFIDFValueMatcher()
 
         # when
-        matches = tfidf_matcher.match(current_values, target_values)
+        matches = tfidf_matcher.match(source_values, target_values)
 
         # then
         self.assertEqual(len(matches), 3)
@@ -32,14 +32,14 @@ class ValueMatchingTest(unittest.TestCase):
 
     def test_edit_distance_value_matching(self):
         # given
-        current_values = ["Red Apple", "Banana", "Oorange", "Strawberry"]
+        source_values = ["Red Apple", "Banana", "Oorange", "Strawberry"]
         target_values = ["apple", "bananana", "orange", "kiwi"]
 
         edit_distance_matcher = EditDistanceValueMatcher(threshold=0.5)
 
         # when
         matches = edit_distance_matcher.match(
-            current_values,
+            source_values,
             target_values,
         )
 


### PR DESCRIPTION
This is another minor change to improve naming consistency throughout the code base and API. The goal is to always use `source_value` (previously was `current_value`) to refer to values that come from the `source` column.