### PR TITLE
refactor: Rename LLM-based methods

### DIFF
--- a/bdikit/matching_evaluation/value_matching.py
+++ b/bdikit/matching_evaluation/value_matching.py
@@ -30,7 +30,7 @@ def get_match_description(match_info):
 
 def evaluate_match(match_info, verbose=False):
     match_description = get_match_description(match_info)
-    print(match_description)
+
     completion = client.chat.completions.create(
         model="gpt-4-turbo-preview",
         messages=[

--- a/bdikit/schema_matching/llm.py
+++ b/bdikit/schema_matching/llm.py
@@ -4,7 +4,7 @@ from openai import OpenAI
 from bdikit.schema_matching.base import BaseTopkSchemaMatcher, ColumnMatch
 
 
-class GPT(BaseTopkSchemaMatcher):
+class LLM(BaseTopkSchemaMatcher):
     def __init__(self, llm_model="gpt-4o-mini"):
         self.llm_model = llm_model
         self.client = self._load_client()

--- a/bdikit/schema_matching/matcher_factory.py
+++ b/bdikit/schema_matching/matcher_factory.py
@@ -67,7 +67,7 @@ class TopkSchemaMatchers(Enum):
         "bdikit.schema_matching.magneto.MagnetoFTLLM",
     )
 
-    GPT = ("gpt", "bdikit.schema_matching.gpt.GPT")
+    LLM = ("llm", "bdikit.schema_matching.llm.LLM")
 
     def __init__(self, matcher_name: str, matcher_path: str):
         self.matcher_name = matcher_name

--- a/bdikit/value_matching/llm.py
+++ b/bdikit/value_matching/llm.py
@@ -6,7 +6,7 @@ from bdikit.utils import get_additional_context
 from bdikit.config import VALUE_MATCHING_THRESHOLD
 
 
-class GPT(BaseValueMatcher):
+class LLM(BaseValueMatcher):
     def __init__(
         self,
         threshold: float = VALUE_MATCHING_THRESHOLD,

--- a/bdikit/value_matching/llm_numeric.py
+++ b/bdikit/value_matching/llm_numeric.py
@@ -12,7 +12,7 @@ from bdikit.value_matching.base import BaseValueMatcher, ValueMatch
 random.seed(42)
 
 
-class GPTNumeric(BaseValueMatcher):
+class LLMNumeric(BaseValueMatcher):
     def __init__(
         self,
         sample_size: int = 5,

--- a/bdikit/value_matching/matcher_factory.py
+++ b/bdikit/value_matching/matcher_factory.py
@@ -9,8 +9,8 @@ class ValueMatchers(Enum):
         "edit_distance",
         "bdikit.value_matching.polyfuzz.EditDistance",
     )
-    GPT = ("gpt", "bdikit.value_matching.gpt.GPT")
-    GPT_NUMERIC = ("gpt_numeric", "bdikit.value_matching.gpt_numeric.GPTNumeric")
+    LLM = ("llm", "bdikit.value_matching.llm.LLM")
+    LLM_NUMERIC = ("llm_numeric", "bdikit.value_matching.llm_numeric.LLMNumeric")
 
     def __init__(self, matcher_name: str, matcher_path: str):
         self.matcher_name = matcher_name

--- a/docs/source/schema-matching.rst
+++ b/docs/source/schema-matching.rst
@@ -36,9 +36,9 @@ To see how to use these methods, please refer to the documentation of :py:func:`
     * - ``two_phase``
       - :class:`~bdikit.schema_matching.twophase.TwoPhase`
       - | The two-phase schema matching method first uses a a top-k column matcher (e.g., `ct_learning`) to prune the search space (keeping only the top-k most likely matches), and then uses another column matcher to choose the best match from the pruned search space.
-    * - ``gpt``
-      - :class:`~bdikit.schema_matching.gpt.GPT`
-      - | This method uses the `ct_learning` to prune the search space and then uses a large language model (GPT4) to choose the best column match, given a set of top-k most likely candidates retrieved using the `ct_learning` method in the first phase.
+    * - ``llm``
+      - :class:`~bdikit.schema_matching.llm.LLM`
+      - | Leverages a large language model (GPT-4) to identify and select the most accurate schema matches.
 
 .. list-table:: Methods from other libraries
     :header-rows: 1

--- a/docs/source/value-matching.rst
+++ b/docs/source/value-matching.rst
@@ -15,11 +15,11 @@ To see how to use these methods, please refer to the documentation of :py:func:`
     * - Method
       - Class
       - Description
-    * - ``gpt``
-      - :class:`~bdikit.value_matching.gpt.GPT`
+    * - ``llm``
+      - :class:`~bdikit.value_matching.llm.LLM`
       - | Leverages a large language model (GPT-4) to identify and select the most accurate value matches.
-    * - ``gpt_numeric``
-      - :class:`~bdikit.value_matching.gpt.GPTNumeric`
+    * - ``llm_numeric``
+      - :class:`~bdikit.value_matching.llm_numeric.LLMNumeric`
       - | Employs a large language model (GPT-4) to perform numeric value transformations, such as converting ages from years to months.
 
 .. list-table:: Methods from other libraries
@@ -36,7 +36,7 @@ To see how to use these methods, please refer to the documentation of :py:func:`
       - | Uses the edit distance between lists of strings using a customizable scorer that supports various distance and similarity metrics.
     * - ``embedding``
       - :class:`~bdikit.value_matching.polyfuzz.Embeddings`
-      - | A value-matching algorithm that leverages the cosine similarity of value embeddings for precise comparisons. By default, it utilizes the `bert-base-multilingual-cased` model to generate contextualized embeddings, enabling effective multilingual matching.​.
+      - | A value-matching algorithm that leverages the cosine similarity of value embeddings for precise comparisons. By default, it utilizes the `bert-base-multilingual-cased` model to generate contextualized embeddings, enabling effective multilingual matching.​
     * - ``fasttext``
       - :class:`~bdikit.value_matching.polyfuzz.FastText`
       - | This method uses the cosine similarity of FastText embeddings to accurately compare and align values, capturing both semantic and subword-level similarities..


### PR DESCRIPTION
This PR introduces the following changes to improve module clarity and reflect broader LLM usage beyond GPT-specific implementations:

## 🧠 Refactoring
- **Renamed modules** to use `llm` instead of `gpt`:
  - `bdikit/schema_matching/gpt.py` → `bdikit/schema_matching/llm.py`
  - `bdikit/value_matching/gpt.py` → `bdikit/value_matching/llm.py`
  - `bdikit/value_matching/gpt_numeric.py` → `bdikit/value_matching/llm_numeric.py`

## 🛠️ Code Updates
- Updated `matcher_factory.py` in both `schema_matching` and `value_matching` to reflect new module names and import paths.
- Modified `value_matching.py` to align with the updated naming conventions and maintain compatibility.

## 📚 Documentation
- Updated the following documentation files to reflect the module renaming:
  - `docs/source/schema-matching.rst`
  - `docs/source/value-matching.rst`
