### PR TITLE
feat: Add a MCP server

### DIFF
--- a/bdikit/mcp.py
+++ b/bdikit/mcp.py
@@ -1,0 +1,268 @@
+import bdikit as bdi
+import pandas as pd
+from os.path import join
+from bdikit.utils import get_class_doc
+from mcp.server.fastmcp import FastMCP
+from bdikit.schema_matching.matcher_factory import schema_matchers, topk_schema_matchers
+from bdikit.value_matching.matcher_factory import topk_value_matchers, value_matchers
+from typing import Any, Optional, Dict, List, Union, Tuple
+
+
+# Initialize FastMCP server
+server = FastMCP("bdikit-harmonizer")
+
+
+@server.tool()
+async def match_schema(
+    source_dataset_path: str,
+    target_dataset_path: Optional[str] = "gdc",
+    method: Optional[str] = "magneto_ft_bp",
+) -> List[Dict[str, Any]]:
+    """Performs schema matching task between the source table and the given target schema
+
+    Args:
+        source_dataset_path: Path to the source CSV data file
+        target_dataset_path: Optional path to target schema (default is "gdc", which uses the GDC schema)
+        method: Optional method to use for schema matching (default is "magneto_ft_bp")
+
+    Returns:
+        Dictionary with schema matching results
+    """
+    source_dataset = pd.read_csv(source_dataset_path)
+
+    if target_dataset_path == "gdc":
+        target_dataset = target_dataset_path
+    else:
+        target_dataset = pd.read_csv(target_dataset_path)
+
+    matches = bdi.match_schema(source_dataset, target=target_dataset, method=method)
+
+    response = matches.to_dict(orient="records")
+
+    return response
+
+
+@server.tool()
+async def rank_schema_matches(
+    source_dataset_path: str,
+    target_dataset_path: Optional[str] = "gdc",
+    columns: Optional[List[str]] = None,
+    top_k: Optional[int] = 10,
+    method: Optional[str] = "magneto_ft_bp",
+) -> List[Dict[str, Any]]:
+    """Returns the top-k matches between the source and target tables. Where k is a value specified by the user.
+
+    Args:
+        source_dataset_path: Path to the source CSV data file
+        target_dataset_path: Optional path to target schema (default is "gdc", which uses the GDC schema)
+        columns: Optional list of columns to match
+        top_k: Optional number of top matches to return (default is 10)
+        method: Optional method to use for schema matching (default is "magneto_ft_bp")
+
+    Returns:
+        Dictionary with schema matching results
+    """
+    source_dataset = pd.read_csv(source_dataset_path)
+
+    if target_dataset_path == "gdc":
+        target_dataset = target_dataset_path
+    else:
+        target_dataset = pd.read_csv(target_dataset_path)
+
+    matches = bdi.rank_schema_matches(
+        source_dataset,
+        target=target_dataset,
+        columns=columns,
+        top_k=top_k,
+        method=method,
+    )
+
+    response = matches.to_dict(orient="records")
+
+    return response
+
+
+@server.tool()
+async def match_values(
+    source_dataset_path: str,
+    target_dataset_path: str,
+    attribute_matches: Union[Tuple[str, str], None],
+    method: Optional[str] = "tfidf",
+) -> List[Dict[str, Any]]:
+    """Finds matches between attribute/column values from the source dataset and attribute/column
+    values of the target schema.
+
+    Args:
+        source_dataset_path: Path to the source CSV data file
+        target_dataset_path: Path to target schema or a standard vocabulary name (e.g. "gdc", which uses the GDC schema)
+        attribute_matches: The attribute/column of the source and target dataset for which to find value matches for.
+            If not provided, it will be calculated using all attributes/columns.
+        method: Optional method to use for value matching (default is "tf-idf")
+
+    Returns:
+        Dictionary with value matching results
+    """
+
+    source_dataset = pd.read_csv(source_dataset_path)
+
+    if target_dataset_path == "gdc":
+        target_dataset = target_dataset_path
+    else:
+        target_dataset = pd.read_csv(target_dataset_path)
+
+    if attribute_matches is None:
+        # Match all attributes if no specific matches are provided
+        attribute_matches = bdi.match_schema(
+            source_dataset,
+            target=target_dataset,
+        )
+
+    matches = bdi.match_values(
+        source_dataset,
+        target_dataset,
+        attribute_matches,
+        method=method,
+    )
+
+    response = matches.to_dict(orient="records")
+
+    return response
+
+
+@server.tool()
+async def rank_value_matches(
+    source_dataset_path: str,
+    target_dataset_path: str,
+    attribute_matches: Union[Tuple[str, str], None],
+    top_k: Optional[int] = 5,
+    method: Optional[str] = "tfidf",
+) -> List[Dict[str, Any]]:
+    """Returns the top-k value matches between the source and target attributes/columns. Where k is a value specified by the user.
+
+    Args:
+        source_dataset_path: Path to the source CSV data file
+        target_dataset_path: Path to target schema or a standard vocabulary name (e.g. "gdc", which uses the GDC schema)
+        attribute_matches: The attribute/column of the source and target dataset for which to find value matches for.
+            If not provided, it will be calculated using all attributes/columns.
+        top_k: Optional number of top matches to return (default is 5)
+        method: Optional method to use for value matching (default is "tf-idf")
+
+    Returns:
+        Dictionary with value matching results
+    """
+
+    source_dataset = pd.read_csv(source_dataset_path)
+
+    if target_dataset_path == "gdc":
+        target_dataset = target_dataset_path
+    else:
+        target_dataset = pd.read_csv(target_dataset_path)
+
+    if attribute_matches is None:
+        # Match all attributes if no specific matches are provided
+        attribute_matches = bdi.match_schema(
+            source_dataset,
+            target=target_dataset,
+        )
+
+    matches = bdi.rank_value_matches(
+        source_dataset,
+        target_dataset,
+        attribute_matches,
+        top_k=top_k,
+        method=method,
+    )
+
+    response = matches.to_dict(orient="records")
+
+    return response
+
+
+@server.tool()
+async def materialize_mapping(
+    source_dataset_path: str,
+    mapping_spec: List[Dict[str, Any]],
+    output_folder_path: str,
+    file_name: Optional[str] = "materialized_data.csv",
+) -> List[Dict[str, Any]]:
+    """Takes the source dataset, the mapping specification, the output folder path, and an optional file name,
+        and materializes the data according to the mapping specification, saving it as a CSV file in the specified output folder.
+
+    Args:
+        source_dataset_path: Path to the source CSV data file
+        mapping_spec: List of dictionaries representing the mapping specification. For instance, the output of the match_values() function:
+            [{'source_attribute': '', 'target_attribute': 'source_value': '','target_value': '', 'similarity': 1}, ...]
+        output_folder_path: Path to the folder where the materialized data will be saved
+        file_name: Optional name for the output CSV file (default is "materialized_data.csv")
+    Returns:
+        Dictionary with a message of the materialization result and the materialized data
+    """
+    source_dataset = pd.read_csv(source_dataset_path)
+
+    # Convert to DataFrame
+    mapping_spec_df = pd.DataFrame(mapping_spec)
+    materialized_data = bdi.materialize_mapping(source_dataset, mapping_spec_df)
+    output_file_path = join(output_folder_path, file_name)
+    materialized_data.to_csv(output_file_path, index=False)
+
+    response = {}
+    response["message"] = f"Materialized data saved successfully in {output_file_path}."
+    response["data"] = materialized_data.to_dict(orient="records")
+
+    return response
+
+
+@server.tool()
+async def get_available_schema_matching_algorithms(
+    mode: str = "top_1",
+) -> List[Dict[str, str]]:
+    """Returns the available schema matching algorithms.
+    Args:
+        mode: The mode of schema matching algorithms to return. Can be "top_1" for single value matchers or "top_k" for top-k value matchers.
+            Default is "top_1".
+    Returns:
+        List of dictionaries with available schema matching algorithms. Each dictionary contains the name and description of the algorithm.
+    """
+
+    if mode == "top_1":
+        available_algorithms = schema_matchers
+    elif mode == "top_k":
+        available_algorithms = topk_schema_matchers
+    else:
+        raise ValueError(
+            "Invalid mode. Use 'top_1' for single value matchers or 'top_k' for top-k value matchers."
+        )
+
+    response = [
+        {"name": name, "description": get_class_doc(path)}
+        for name, path in available_algorithms.items()
+    ]
+    return response
+
+
+@server.tool()
+async def get_available_value_matching_algorithms(
+    mode: str = "top_1",
+) -> List[Dict[str, str]]:
+    """Returns the available value matching algorithms.
+    Args:
+        mode: The mode of value matching algorithms to return. Can be "top_1" for single value matchers or "top_k" for top-k value matchers.
+            Default is "top_1".
+    Returns:
+        List of dictionaries with available value matching algorithms. Each dictionary contains the name and description of the algorithm.
+    """
+
+    if mode == "top_1":
+        available_algorithms = value_matchers
+    elif mode == "top_k":
+        available_algorithms = topk_value_matchers
+    else:
+        raise ValueError(
+            "Invalid mode. Use 'top_1' for single value matchers or 'top_k' for top-k value matchers."
+        )
+
+    response = [
+        {"name": name, "description": get_class_doc(path)}
+        for name, path in available_algorithms.items()
+    ]
+    return response

--- a/bdikit/schema_matching/llm.py
+++ b/bdikit/schema_matching/llm.py
@@ -5,6 +5,8 @@ from bdikit.schema_matching.base import BaseTopkSchemaMatcher, ColumnMatch
 
 
 class LLM(BaseTopkSchemaMatcher):
+    """A schema matcher that uses LLM to match columns based on their similarity."""
+
     def __init__(self, llm_model="gpt-4o-mini"):
         self.llm_model = llm_model
         self.client = self._load_client()

--- a/bdikit/schema_matching/magneto.py
+++ b/bdikit/schema_matching/magneto.py
@@ -58,11 +58,15 @@ class MagnetoBase(BaseTopkSchemaMatcher):
 
 
 class MagnetoZSBP(MagnetoBase):
+    """Uses a zero-shot small language model as retriever with the bipartite algorithm as reranker in Magneto."""
+
     def __init__(self):
         super().__init__()
 
 
 class MagnetoFTBP(MagnetoBase):
+    """Uses a fine-tuned small language model as retriever with the bipartite algorithm as reranker in Magneto."""
+
     def __init__(
         self,
         encoding_mode: str = "header_values_verbose",
@@ -75,15 +79,15 @@ class MagnetoFTBP(MagnetoBase):
 
 
 class MagnetoZSLLM(MagnetoBase):
+    """Uses a zero-shot small language model as retriever with a large language model as reranker in Magneto."""
+
     def __init__(self):
         kwargs = {"use_bp_reranker": False, "use_gpt_reranker": True}
         super().__init__(kwargs)
 
 
 class MagnetoFTLLM(MagnetoBase):
-    """
-    Magneto is an innovative framework designed to enhance schema matching (SM) by intelligently combining small, pre-trained language models (SLMs) with large language models (LLMs). The first phase involves using a fine-tuned SLMs to quickly identify a manageable subset of potential matches from a vast pool of possibilities. In the second phase, LLMs take over to assess and reorder the candidates, simplifying the process for users to review and select the most suitable matches.
-    """
+    """Uses a fine-tuned small language model as retriever with a large language model as reranker in Magneto."""
 
     def __init__(
         self,

--- a/bdikit/schema_matching/twophase.py
+++ b/bdikit/schema_matching/twophase.py
@@ -11,6 +11,8 @@ from bdikit.schema_matching.magneto import MagnetoFTBP
 
 
 class TwoPhase(BaseSchemaMatcher):
+    """A two-phase schema matcher that first ranks columns using a top-k matcher and then applies a schema matcher to the top-k matches."""
+
     def __init__(
         self,
         top_k: int = 20,

--- a/bdikit/schema_matching/valentine.py
+++ b/bdikit/schema_matching/valentine.py
@@ -37,6 +37,8 @@ class Valentine(BaseSchemaMatcher):
 
 
 class SimFlood(Valentine):
+    """Similarity Flooding transforms schemas into directed graphs and merges them into a propagation graph. The algorithm iteratively propagates similarity scores to neighboring nodes until convergence."""
+
     def __init__(
         self, coeff_policy: str = "inverse_average", formula: str = "formula_c"
     ):
@@ -46,6 +48,8 @@ class SimFlood(Valentine):
 
 
 class Coma(Valentine):
+    """COMA is a matcher that combines multiple schema-based matchers, representing schemas as rooted directed acyclic graphs."""
+
     def __init__(
         self, max_n: int = 0, use_instances: bool = False, java_xmx: str = "1024m"
     ):
@@ -55,6 +59,8 @@ class Coma(Valentine):
 
 
 class Cupid(Valentine):
+    """Cupid calculates overall similarity using linguistic and structural similarities, with tree transformations helping to compute context-based similarity."""
+
     def __init__(
         self,
         leaf_w_struct: float = 0.2,
@@ -83,6 +89,8 @@ class Cupid(Valentine):
 
 
 class DistributionBased(Valentine):
+    """Distribution-based Matching compares the distribution of data values in columns using the Earth Mover’s Distance. It clusters relational attributes based on these comparisons."""
+
     def __init__(
         self,
         threshold1: float = 0.15,

--- a/bdikit/utils.py
+++ b/bdikit/utils.py
@@ -164,6 +164,23 @@ def create_matcher(
     return getattr(module, class_name)(**matcher_kwargs)
 
 
+def get_class_doc(import_path: str):
+    module_path, class_name = import_path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+
+    # Get the class from the module
+    cls = getattr(module, class_name)
+
+    # Get the class docstring
+
+    doc = cls.__doc__
+
+    if doc is None:
+        return f"The class {class_name} does not have description."
+
+    return cls.__doc__.strip()
+
+
 def get_additional_context(context: Dict[str, str], dataset_label: str) -> str:
     """
     Generate a string with additional context information from the provided context dictionary.

--- a/bdikit/value_matching/llm.py
+++ b/bdikit/value_matching/llm.py
@@ -7,6 +7,8 @@ from bdikit.config import VALUE_MATCHING_THRESHOLD
 
 
 class LLM(BaseValueMatcher):
+    """A value matcher that uses LLM to match values based on their similarity."""
+
     def __init__(
         self,
         threshold: float = VALUE_MATCHING_THRESHOLD,

--- a/bdikit/value_matching/llm_numeric.py
+++ b/bdikit/value_matching/llm_numeric.py
@@ -13,6 +13,8 @@ random.seed(42)
 
 
 class LLMNumeric(BaseValueMatcher):
+    """A value matcher that uses LLM to derive formulas for numeric value matching."""
+
     def __init__(
         self,
         sample_size: int = 5,

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -7,3 +7,4 @@ Here you can find different Jupyter notebook examples about how to use `bdi-kit`
 - :example:`Changing  the parameters of the matching methods <changing_parameters.ipynb>`
 - :example:`Getting the top-k value matches <top_k_value_matches.ipynb>`
 - :example:`Analyzing one attribute/column at a time <analyzing_one_attribute.ipynb>`
+- :example:`Run a MCP server <mcp_server.py>`

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,6 +8,13 @@ This package works with Python 3.8+ in Linux and Mac. You can install the latest
    $ pip install bdi-kit
 
 
+To use bdi-kit from AI agents or assistants via Model Context Protocol (MCP), install:
+
+::
+
+   $ pip install bdi-kit[mcp]
+
+
 To install the latest development version:
 
 ::

--- a/examples/mcp_server.py
+++ b/examples/mcp_server.py
@@ -1,0 +1,6 @@
+from bdikit.mcp import server
+# Run the MCP server
+# This will start the server and listen for requests on standard input/output. 
+# So, you need a client to send requests to this server.
+# The server will handle schema matching, value matching, and other tasks as defined in the tools
+server.run(transport="stdio")

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,11 @@ setuptools.setup(
     version=version,
     packages=setuptools.find_packages(),
     install_requires=requires,
-    extras_require=extra_requires,
+    extras_require={
+        'mcp': ['mcp[cli]']
+    },
     python_requires='>=3.9',
-    description="bdi-kit library",
+    description="BDI-Kit Library",
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/VIDA-NYU/bdi-kit',
@@ -50,7 +52,7 @@ setuptools.setup(
     author_email='',
     maintainer='',
     maintainer_email='',
-    keywords=['askem', 'data integration', 'nyu'],
+    keywords=['BDF', 'Data Harmonization', 'NYU'],
     license='Apache-2.0',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This pull request introduces a MCP server that provides access to BDI-Kit’s core schema and value matching capabilities. The server exposes a set of tools that can be consumed by agents, assistants, or other applications needing harmonization services.

## 🚀 Main Features

- **Schema matching endpoints**:
  - `match_schema`: Performs schema matching between a source dataset and a target schema
  - `rank_schema_matches`: Returns top-k ranked schema matches
- **Value matching endpoints**:
  - `match_values`: Performs value-level matching between aligned attributes of two datasets
  - `rank_value_matches`: Returns top-k ranked value matches
- **Materialization**:
  - `materialize_mapping`: Applies a mapping specification to a dataset and exports the result to CSV
- **Utility endpoints**:
  - `get_available_schema_matching_algorithms`: Lists supported schema matching algorithms (`top_1` and `top_k`)
  - `get_available_value_matching_algorithms`: Lists supported value matching algorithms (`top_1` and `top_k`)


This addition enables easier automation, deployment, and remote use of BDI-Kit harmonization pipelines via MCP.
