### PR TITLE
feat: Add caching for value matching and improve schema matching cache

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -398,7 +398,7 @@ def test_end_to_end_api_integration():
 
     # when: we pass the output of match_schema()
     value_mappings = bdi.match_values(
-        df_source, df_target, column_mappings, method="tfidf"
+        df_source, df_target, column_mappings, method="tfidf", use_cache=False
     )
 
     # then: a list of value matches must be computed


### PR DESCRIPTION
This PR introduces a caching mechanism for value matching and improves the existing caching logic for schema matching. The goal is to reduce redundant computations and improve response time, particularly during  repeated usage or demos.

### ✅  Summary of changes
- **Value matching**
  - Added optional `use_cache` parameter (default: `True`) to `match_values()` and `rank_value_matches()`
  - Introduced `_cache_value_matches()` utility for handling value-level caching
  - Implemented `create_value_hash()` for generating unique and stable cache keys
- **Schema matching**
  - Refactored cache logic via `_cache_schema_matches()` for both `match_schema()` and `rank_schema_matches()`
  - Replaced `create_hash()` with more flexible `create_schema_hash()` function
- **Hashing improvements**
  - Enhanced `hash_object()` to serialize only the constructor arguments of matcher objects when available, for consistent and meaningful hashing

### 🚀 Impact
- Caching is **enabled by default** but can be disabled via the `use_cache` flag
- Improves performance without changing the existing API behavior
