### PR TITLE
refactor: Rename BaseStandard functions for consistency

### DIFF
--- a/bdikit/api.py
+++ b/bdikit/api.py
@@ -676,15 +676,15 @@ def preview_domain(
         if standard_args is None:
             standard_args = {}
         standard = Standards.get_standard(dataset, **standard_args)
-        column_metadata = standard.get_column_metadata([attribute])
-        value_names = column_metadata[attribute]["value_names"]
-        value_descriptions = column_metadata[attribute]["value_descriptions"]
-        column_description = column_metadata[attribute]["description"]
+        attribute_metadata = standard.get_attribute_metadata([attribute])
+        value_names = attribute_metadata[attribute]["value_names"]
+        value_descriptions = attribute_metadata[attribute]["value_descriptions"]
+        attribute_description = attribute_metadata[attribute]["description"]
         assert len(value_names) == len(value_descriptions)
     elif isinstance(dataset, pd.DataFrame):
         value_names = dataset[attribute].unique()
         value_descriptions = []
-        column_description = ""
+        attribute_description = ""
     else:
         raise ValueError(
             "The dataset must be a DataFrame or a standard vocabulary name."
@@ -702,9 +702,11 @@ def preview_domain(
     if len(value_descriptions) > 0:
         domain["value_description"] = value_descriptions
 
-    if len(column_description) > 0:
+    if len(attribute_description) > 0:
         empty_rows_size = len(value_names) - 1
-        domain["attribute_description"] = [column_description] + [""] * empty_rows_size
+        domain["attribute_description"] = [attribute_description] + [
+            ""
+        ] * empty_rows_size
 
     return pd.DataFrame(domain)
 
@@ -840,7 +842,7 @@ def _create_context(
     # Auto-generated context
     auto_context = {
         "attribute_name": attribute,
-        "attribute_description": dataset.get_column_metadata([attribute])[attribute][
+        "attribute_description": dataset.get_attribute_metadata([attribute])[attribute][
             "description"
         ],
     }
@@ -866,8 +868,8 @@ def _iterate_values(
 ):
 
     attribute_matches_list = _format_attribute_matches(attribute_matches)
-    all_target_values = target.get_column_values(target.get_columns())
-    all_source_values = source.get_column_values(source.get_columns())
+    all_target_values = target.get_attribute_values(target.get_attributes())
+    all_source_values = source.get_attribute_values(source.get_attributes())
 
     for attribute_match in attribute_matches_list:
         source_attribute, target_attribute = (

--- a/bdikit/standards/base.py
+++ b/bdikit/standards/base.py
@@ -7,14 +7,27 @@ class BaseStandard:
     Base class for all target standards, e.g. GDC.
     """
 
-    def get_columns(self) -> List[str]:
+    def get_attributes(self) -> List[str]:
+        """
+        Returns a list of all the attributes (strings) of the standard.
+        """
         raise NotImplementedError("Subclasses must implement this method")
 
-    def get_column_values(self, column_names: List[str]) -> Dict[str, List]:
+    def get_attribute_values(self, attribute_names: List[str]) -> Dict[str, List]:
+        """
+        Returns a dictionary where the keys are attribute names and the values are lists of possible values for each attribute.
+        """
         raise NotImplementedError("Subclasses must implement this method")
 
-    def get_column_metadata(self, column_names: List[str]) -> Dict[str, Dict]:
+    def get_attribute_metadata(self, attribute_names: List[str]) -> Dict[str, Dict]:
+        """
+        Returns a dictionary where the keys are attribute names and the values are dictionaries containing these fields for each attribute:
+        `description`, `value_names`, and `value_descriptions`.
+        """
         raise NotImplementedError("Subclasses must implement this method")
 
     def get_dataframe_rep(self) -> pd.DataFrame:
+        """
+        Returns a Pandas DataFrame representation of the standard, where each column in the DataFrame is an attribute in the standard and each row is a possible value for that attribute.
+        """
         raise NotImplementedError("Subclasses must implement this method")

--- a/bdikit/standards/dataframe.py
+++ b/bdikit/standards/dataframe.py
@@ -8,31 +8,31 @@ class DataFrame(BaseStandard):
     def __init__(self, dataframe) -> None:
         self.dataframe = dataframe
 
-    def get_columns(self) -> List[str]:
+    def get_attributes(self) -> List[str]:
         return list(self.dataframe.columns)
 
-    def get_column_values(self, column_names: List[str]) -> Dict[str, List]:
-        column_values = {}
+    def get_attribute_values(self, attribute_names: List[str]) -> Dict[str, List]:
+        attribute_values = {}
 
-        column_values = {
-            column_name: self.dataframe[column_name].unique().tolist()
-            for column_name in column_names
+        attribute_values = {
+            attribute_name: self.dataframe[attribute_name].unique().tolist()
+            for attribute_name in attribute_names
         }
 
-        return column_values
+        return attribute_values
 
-    def get_column_metadata(self, column_names: List[str]) -> Dict[str, Dict]:
-        column_metadata = {}
+    def get_attribute_metadata(self, attribute_names: List[str]) -> Dict[str, Dict]:
+        attribute_metadata = {}
 
-        for column_name in column_names:
-            column_metadata[column_name] = {}
-            column_metadata[column_name]["description"] = ""
-            column_metadata[column_name]["value_names"] = self.get_column_values(
-                [column_name]
-            )[column_name]
-            column_metadata[column_name]["value_descriptions"] = []
+        for attribute_name in attribute_names:
+            attribute_metadata[attribute_name] = {}
+            attribute_metadata[attribute_name]["description"] = ""
+            attribute_metadata[attribute_name]["value_names"] = (
+                self.get_attribute_values([attribute_name])[attribute_name]
+            )
+            attribute_metadata[attribute_name]["value_descriptions"] = []
 
-        return column_metadata
+        return attribute_metadata
 
     def get_dataframe_rep(self) -> pd.DataFrame:
         return self.dataframe

--- a/bdikit/standards/gdc.py
+++ b/bdikit/standards/gdc.py
@@ -21,39 +21,41 @@ class GDC(BaseStandard):
         with open(GDC_SCHEMA_PATH) as json_file:
             self.data = json.load(json_file)
 
-    def get_columns(self) -> List[str]:
+    def get_attributes(self) -> List[str]:
         return list(self.data.keys())
 
-    def get_column_values(
-        self, column_names: List[str]
+    def get_attribute_values(
+        self, attribute_names: List[str]
     ) -> Dict[str, List]:  # get_gdc_data
-        column_values = {}
+        attribute_values = {}
 
-        for column_name in column_names:
-            raw_metadata = self.data.get(column_name, {})
-            column_values[column_name] = list(raw_metadata.get("value_data", {}).keys())
-
-        return column_values
-
-    def get_column_metadata(
-        self, column_names: List[str]
-    ) -> Dict[str, Dict]:  # get_gdc_metadata
-        column_metadata = {}
-
-        for column_name in column_names:
-            raw_metadata = self.data.get(column_name, {})
-            column_metadata[column_name] = {}
-            column_metadata[column_name]["description"] = raw_metadata.get(
-                "column_description", ""
-            )
-            column_metadata[column_name]["value_names"] = list(
+        for attribute_name in attribute_names:
+            raw_metadata = self.data.get(attribute_name, {})
+            attribute_values[attribute_name] = list(
                 raw_metadata.get("value_data", {}).keys()
             )
-            column_metadata[column_name]["value_descriptions"] = list(
+
+        return attribute_values
+
+    def get_attribute_metadata(
+        self, attribute_names: List[str]
+    ) -> Dict[str, Dict]:  # get_gdc_metadata
+        attribute_metadata = {}
+
+        for attribute_name in attribute_names:
+            raw_metadata = self.data.get(attribute_name, {})
+            attribute_metadata[attribute_name] = {}
+            attribute_metadata[attribute_name]["description"] = raw_metadata.get(
+                "column_description", ""
+            )
+            attribute_metadata[attribute_name]["value_names"] = list(
+                raw_metadata.get("value_data", {}).keys()
+            )
+            attribute_metadata[attribute_name]["value_descriptions"] = list(
                 raw_metadata.get("value_data", {}).values()
             )
 
-        return column_metadata
+        return attribute_metadata
 
     def get_dataframe_rep(self) -> pd.DataFrame:
         reshaped_data = {

--- a/bdikit/standards/synapse.py
+++ b/bdikit/standards/synapse.py
@@ -34,35 +34,37 @@ class Synapse(BaseStandard):
         for entity in entities:
             self.data[entity] = data["entity"][entity]
 
-    def get_columns(self) -> List[str]:
+    def get_attributes(self) -> List[str]:
         return list(self.data.keys())
 
-    def get_column_values(self, column_names: List[str]) -> Dict[str, List]:
-        column_values = {}
+    def get_attribute_values(self, attribute_names: List[str]) -> Dict[str, List]:
+        attribute_values = {}
 
-        for column_name in column_names:
-            raw_metadata = self.data.get(column_name, {})
-            column_values[column_name] = list(raw_metadata.get("value_data", {}).keys())
-
-        return column_values
-
-    def get_column_metadata(self, column_names: List[str]) -> Dict[str, Dict]:
-        column_metadata = {}
-
-        for column_name in column_names:
-            raw_metadata = self.data.get(column_name, {})
-            column_metadata[column_name] = {}
-            column_metadata[column_name]["description"] = raw_metadata.get(
-                "column_description", ""
-            )
-            column_metadata[column_name]["value_names"] = list(
+        for attribute_name in attribute_names:
+            raw_metadata = self.data.get(attribute_name, {})
+            attribute_values[attribute_name] = list(
                 raw_metadata.get("value_data", {}).keys()
             )
-            column_metadata[column_name]["value_descriptions"] = list(
+
+        return attribute_values
+
+    def get_attribute_metadata(self, attribute_names: List[str]) -> Dict[str, Dict]:
+        attribute_metadata = {}
+
+        for attribute_name in attribute_names:
+            raw_metadata = self.data.get(attribute_name, {})
+            attribute_metadata[attribute_name] = {}
+            attribute_metadata[attribute_name]["description"] = raw_metadata.get(
+                "column_description", ""
+            )
+            attribute_metadata[attribute_name]["value_names"] = list(
+                raw_metadata.get("value_data", {}).keys()
+            )
+            attribute_metadata[attribute_name]["value_descriptions"] = list(
                 raw_metadata.get("value_data", {}).values()
             )
 
-        return column_metadata
+        return attribute_metadata
 
     def get_dataframe_rep(self) -> pd.DataFrame:
         reshaped_data = {

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -58,10 +58,10 @@ Contributors can extend bdi-kit to additional standards (data models) by followi
 1. Create a Python module inside the "standards" folder (`bdikit/standards`). 
 2. Define a class in the module to implements `BaseStandard`. This class should implement four methods:
 
-   - `get_columns()`: Returns a list of all the columns (strings) of the standard.
-   - `get_column_values()`: Returns a dictionary where the keys are column names and the values are lists of possible values for each column.
-   - `get_column_metadata()`: Returns a dictionary where the keys are column names and the values are dictionaries containing these fields for each column:
-     `column_description`, `value_names`, and `value_descriptions`.
+   - `get_attributes()`: Returns a list of all the attributes (strings) of the standard.
+   - `get_attribute_values()`: Returns a dictionary where the keys are attribute names and the values are lists of possible values for each attribute.
+   - `get_attribute_metadata()`: Returns a dictionary where the keys are attribute names and the values are dictionaries containing these fields for each attribute:
+     `description`, `value_names`, and `value_descriptions`.
    - `get_dataframe_rep()`: Returns a Pandas DataFrame representation of the standard, where each column in the DataFrame is a column in the standard and each row is a possible value for that column.
 
 3. Add a new entry to the class `Standards(Enum)` in `bdikit/standards/standard_factory.py`. Make sure to add the correct import path for your module to ensure it can be accessed without errors.


### PR DESCRIPTION
This PR refactors the `BaseStandard` class and related implementations to ensure consistency in terminology across the codebase. Specifically, the changes rename methods and variables from **column**-based naming to **attribute**-based naming. This aligns with the conceptual model used in `bdi-kit`, where standards define attributes rather than raw table columns.

## Changes
- **Renamed methods in `BaseStandard`:**
  - `get_columns()` → `get_attributes()`
  - `get_column_values()` → `get_attribute_values()`
  - `get_column_metadata()` → `get_attribute_metadata()`

- **Updated all implementations to match the new method names:**
  - `bdikit/standards/base.py`
  - `bdikit/standards/dataframe.py`
  - `bdikit/standards/gdc.py`
  - `bdikit/standards/synapse.py`


- **Documentation updates:**
  - Updated `docs/source/contributing.rst` to reflect the new method names and consistent terminology.

## Rationale
This refactor improves clarity and avoids confusion between dataset columns (which may vary across data sources) and standardized attributes (defined consistently in `bdi-kit` standards). It also makes the API more intuitive for contributors extending the toolkit.

## Impact
- **Breaking Change:**  
  Any external code relying on `BaseStandard` methods with `column_` prefixes will need to be updated.
- **Internal Consistency:**  
  All internal references have been updated, so the toolkit should continue to function correctly.
- **Documentation:**  
  Contributor guidelines and API references now reflect the new naming scheme.