### PR TITLE
feat: Abstract LLM-based primitives for greater flexibility

### DIFF
--- a/bdikit/api.py
+++ b/bdikit/api.py
@@ -46,6 +46,13 @@ from bdikit.utils import (
     create_value_hash,
 )
 
+from bdikit.matching_evaluation.schema_matching import (
+    evaluate_match as evaluate_schema_match,
+)
+from bdikit.matching_evaluation.value_matching import (
+    evaluate_match as evaluate_value_match,
+)
+
 pn.extension("tabulator")
 
 logger = logging.getLogger(__name__)
@@ -731,13 +738,11 @@ def evaluate_schema_matches(
         pd.DataFrame: A DataFrame containing the evaluated matches with additional columns
         'response' and 'explanation'.
     """
-    from bdikit.matching_evaluation.schema_matching import evaluate_match
-
     evaluated_matches = schema_matches.copy()
 
     evaluated_matches["response"], evaluated_matches["explanation"] = zip(
         *evaluated_matches.apply(
-            lambda row: evaluate_match(
+            lambda row: evaluate_schema_match(
                 {
                     "source_column": row["source_attribute"],
                     "target_column": row["target_attribute"],
@@ -774,13 +779,11 @@ def evaluate_value_matches(
         pd.DataFrame: A DataFrame containing the evaluated matches with additional columns
         'response' and 'explanation'.
     """
-    from bdikit.matching_evaluation.value_matching import evaluate_match
-
     evaluated_matches = value_matches.copy()
 
     evaluated_matches["response"], evaluated_matches["explanation"] = zip(
         *evaluated_matches.apply(
-            lambda row: evaluate_match(
+            lambda row: evaluate_value_match(
                 {
                     "source_value": row["source_value"],
                     "target_value": row["target_value"],

--- a/bdikit/matching_evaluation/schema_matching.py
+++ b/bdikit/matching_evaluation/schema_matching.py
@@ -1,9 +1,6 @@
 import json_repair
 import warnings
-from openai import OpenAI
-
-
-client = OpenAI()
+from litellm import completion
 
 
 def get_match_description(match_info):
@@ -26,11 +23,13 @@ def get_match_description(match_info):
     return description
 
 
-def evaluate_match(match_info, verbose=False):
+def evaluate_match(
+    match_info, model_name="openai/gpt-4o-mini", verbose=False, **model_kwargs
+):
     match_description = get_match_description(match_info)
 
-    completion = client.chat.completions.create(
-        model="gpt-4-turbo-preview",
+    response = completion(
+        model=model_name,
         messages=[
             {
                 "role": "system",
@@ -54,9 +53,10 @@ def evaluate_match(match_info, verbose=False):
                 "content": f"These are the details of the match: {match_description}",
             },
         ],
+        **model_kwargs,
     )
 
-    response_message = completion.choices[0].message.content
+    response_message = response.choices[0].message.content
     try:
         response_dict = json_repair.loads(response_message)
         decision_class = response_dict["response"]
@@ -65,7 +65,7 @@ def evaluate_match(match_info, verbose=False):
     except:
         if verbose:
             warnings.warn(
-                f"Failed to parse response from OpenAI API: {response_message}. ",
+                f"Failed to parse response: {response_message}. ",
                 UserWarning,
             )
 

--- a/bdikit/matching_evaluation/value_matching.py
+++ b/bdikit/matching_evaluation/value_matching.py
@@ -1,9 +1,6 @@
 import json_repair
 import warnings
-from openai import OpenAI
-
-
-client = OpenAI()
+from litellm import completion
 
 
 def get_match_description(match_info):
@@ -28,11 +25,13 @@ def get_match_description(match_info):
     return description
 
 
-def evaluate_match(match_info, verbose=False):
+def evaluate_match(
+    match_info, model_name="openai/gpt-4o-mini", verbose=False, **model_kwargs
+):
     match_description = get_match_description(match_info)
 
-    completion = client.chat.completions.create(
-        model="gpt-4-turbo-preview",
+    response = completion(
+        model=model_name,
         messages=[
             {
                 "role": "system",
@@ -58,7 +57,7 @@ def evaluate_match(match_info, verbose=False):
         ],
     )
 
-    response_message = completion.choices[0].message.content
+    response_message = response.choices[0].message.content
     try:
         response_dict = json_repair.loads(response_message)
         decision_class = response_dict["response"]
@@ -67,7 +66,7 @@ def evaluate_match(match_info, verbose=False):
     except:
         if verbose:
             warnings.warn(
-                f"Failed to parse response from OpenAI API: {response_message}. ",
+                f"Failed to parse response: {response_message}. ",
                 UserWarning,
             )
 

--- a/bdikit/schema_matching/llm.py
+++ b/bdikit/schema_matching/llm.py
@@ -1,26 +1,16 @@
-import os
-import re
-from openai import OpenAI
+import warnings
+import json_repair
+from litellm import completion
 from bdikit.schema_matching.base import BaseTopkSchemaMatcher, ColumnMatch
 
 
 class LLM(BaseTopkSchemaMatcher):
     """A schema matcher that uses LLM to match columns based on their similarity."""
 
-    def __init__(self, llm_model="gpt-4o-mini"):
-        self.llm_model = llm_model
-        self.client = self._load_client()
+    def __init__(self, model_name="openai/gpt-4o-mini", **model_kwargs):
+        self.model_name = model_name
+        self.model_kwargs = model_kwargs
         self.llm_attempts = 5
-
-    def _load_client(self):
-        if self.llm_model in ["gpt-4-turbo-preview", "gpt-4o-mini"]:
-            api_key = os.getenv("OPENAI_API_KEY")
-            if not api_key:
-                raise ValueError("API key not found in environment variables.")
-            return OpenAI(api_key=api_key)
-
-        else:
-            raise ValueError("Invalid model name.")
 
     def _sample_values(self, column, max_samples=5):
         values = column.drop_duplicates().dropna()
@@ -55,8 +45,9 @@ class LLM(BaseTopkSchemaMatcher):
             attempts = 0
             while True:
                 if attempts >= self.llm_attempts:
-                    print(
-                        f"Failed to parse response after {self.llm_attempts} attempts. Skipping."
+                    warnings.warn(
+                        f"Failed to parse response after {self.llm_attempts} attempts. Skipping.",
+                        UserWarning,
                     )
                     refined_match = []
                     break
@@ -78,19 +69,17 @@ class LLM(BaseTopkSchemaMatcher):
 
     def _get_prompt(self, cand, targets):
         prompt = (
-            "From a score of 0.00 to 1.00, please judge the similarity of the candidate column from the candidate table to each target column in the target table. \
-All the columns are defined by the column name and a sample of its respective values if available. \
-Provide only the name of each target column followed by its similarity score in parentheses, formatted to two decimals, and separated by a semicolon. \
-Rank the schema-score pairs by score in descending order. Ensure your response excludes additional information and quotations.\n \
-Example:\n \
-Candidate Column: \
-Column: EmployeeID, Sample values: [100, 101, 102]\n \
-Target Schemas: \
-Column: WorkerID, Sample values: [100, 101, 102] \
-Column: EmpCode, Sample values: [001, 002, 003] \
-Column: StaffName, Sample values: ['Alice', 'Bob', 'Charlie']\n \
-Response: WorkerID(0.95); EmpCode(0.30); StaffName(0.05)\n\n \
-Candidate Column:"
+            "Given a candidate column and a list of target columns, judge the similarity between the candidate and each target column. "
+            "Return a JSON array of objects, each with 'column' (the target column name) and 'score' (a float between 0 and 1, two decimals, 1 is most similar). "
+            "Do NOT provide any other output text or explanation. Only provide the JSON array.\n"
+            "Example:\n"
+            "Candidate Column: Column: EmployeeID, Sample values: [100, 101, 102]\n"
+            "Target Schemas:\n"
+            "Column: WorkerID, Sample values: [100, 101, 102]\n"
+            "Column: EmpCode, Sample values: [001, 002, 003]\n"
+            "Column: StaffName, Sample values: ['Alice', 'Bob', 'Charlie']\n"
+            'Response: [\n  {"column": "WorkerID", "score": 0.95},\n  {"column": "EmpCode", "score": 0.30},\n  {"column": "StaffName", "score": 0.05}\n]\n\n'
+            "Candidate Column: "
             + cand
             + "\n\nTarget Schemas:\n"
             + targets
@@ -100,65 +89,38 @@ Candidate Column:"
 
     def _get_matches(self, cand, targets):
         prompt = self._get_prompt(cand, targets)
-        if self.llm_model in [
-            "gpt-4-turbo-preview",
-            "gpt-4o-mini",
-            "llama3.3-70b",
-            "meta-llama/Llama-3.3-70B-Instruct",
-        ]:
-            messages = [
-                {
-                    "role": "system",
-                    "content": "You are an AI trained to perform schema matching by providing column similarity scores.",
-                },
-                {
-                    "role": "user",
-                    "content": prompt,
-                },
-            ]
+        messages = [
+            {
+                "role": "system",
+                "content": "You are an AI trained to perform schema matching by providing column similarity scores.",
+            },
+            {
+                "role": "user",
+                "content": prompt,
+            },
+        ]
 
-            response = self.client.chat.completions.create(
-                model=self.llm_model,
-                messages=messages,
-                temperature=0.3,
-            )
-            matches = response.choices[0].message.content
-
-        else:
-            raise ValueError("Invalid model name.")
+        response = completion(
+            model=self.model_name,
+            messages=messages,
+            **self.model_kwargs,
+        )
+        matches = response.choices[0].message.content
 
         return matches
 
     def _parse_matches(self, refined_match):
-        matched_columns = []
-        entries = refined_match.split("; ")
-
-        for entry in entries:
-            try:
-                schema_part, score_part = entry.rsplit("(", 1)
-            except ValueError:
-                print(f"Error parsing entry: {entry}")
-                return None
-
-            try:
-                score = float(score_part[:-1])
-            except ValueError:
-                # Remove all trailing ')'
-                score_part = score_part[:-1].rstrip(")")
-                try:
-                    score = float(score_part)
-                except ValueError:
-                    cleaned_part = re.sub(
-                        r"[^\d\.-]", "", score_part
-                    )  # Remove everything except digits, dot, and minus
-                    match = re.match(r"^-?\d+\.\d{2}$", cleaned_part)
-                    if match:
-                        score = float(match.group())
-                    else:
-                        print("The string does not contain a valid two decimal float.")
-                        return None
-
-            schema_name = schema_part.strip()
-            matched_columns.append((schema_name, score))
-
-        return matched_columns
+        try:
+            matches_json = json_repair.loads(refined_match)
+            matched_columns = []
+            for entry in matches_json:
+                schema_name = entry.get("column")
+                score = float(entry.get("score", 0))
+                matched_columns.append((schema_name, score))
+            return matched_columns
+        except Exception as e:
+            warnings.warn(
+                f"Error parsing JSON response: {e}\nRaw response: {refined_match}",
+                UserWarning,
+            )
+            return None

--- a/docs/source/schema-matching.rst
+++ b/docs/source/schema-matching.rst
@@ -35,7 +35,7 @@ To see how to use these methods, please refer to the documentation of :py:func:`
       - | The two-phase schema matching method first uses a a top-k column matcher (e.g., `ct_learning`) to prune the search space (keeping only the top-k most likely matches), and then uses another column matcher to choose the best match from the pruned search space.
     * - ``llm``
       - :class:`~bdikit.schema_matching.llm.LLM`
-      - | Leverages a large language model (GPT-4) to identify and select the most accurate schema matches.
+      - | Leverages a large language model (GPT-4 by default) to identify and select the most accurate schema matches.
 
 .. list-table:: Methods from other libraries
     :header-rows: 1

--- a/docs/source/value-matching.rst
+++ b/docs/source/value-matching.rst
@@ -17,10 +17,10 @@ To see how to use these methods, please refer to the documentation of :py:func:`
       - Description
     * - ``llm``
       - :class:`~bdikit.value_matching.llm.LLM`
-      - | Leverages a large language model (GPT-4) to identify and select the most accurate value matches.
+      - | Leverages a large language model (GPT-4 by default) to identify and select the most accurate value matches.
     * - ``llm_numeric``
       - :class:`~bdikit.value_matching.llm_numeric.LLMNumeric`
-      - | Employs a large language model (GPT-4) to perform numeric value transformations, such as converting ages from years to months.
+      - | Employs a large language model (GPT-4 by default) to perform numeric value transformations, such as converting ages from years to months.
 
 .. list-table:: Methods from other libraries
     :header-rows: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 polyfuzz
+pandas
 valentine>0.2.0
-openai
 torch
 transformers
 tqdm
@@ -13,3 +13,4 @@ panel!=1.4.3
 nltk>=3.9.1
 magneto-python
 json-repair
+litellm

--- a/tests/test_matcher_factory.py
+++ b/tests/test_matcher_factory.py
@@ -16,11 +16,6 @@ from bdikit.value_matching.matcher_factory import (
 )
 
 
-# Set a mock API key to test only the initialization of the matcher
-# This is necessary because the OpenAI client requires an API key to be set
-os.environ["OPENAI_API_KEY"] = "mock_key"
-
-
 def test_get_schema_matcher():
     for matcher in SchemaMatchers:
         obj = get_schema_matcher(matcher.matcher_name)


### PR DESCRIPTION
This PR abstracts the LLM-based primitives in **schema matching** and **value matching** so they are no longer tied to a specific provider (e.g., OpenAI).  
Instead, they can be configured with any LLM supported by [LiteLLM](https://github.com/BerriAI/litellm), making the toolkit more flexible and backend-agnostic.

## Changes

- **Refactored `LLM`, `LLMNumeric`, and related classes**  
  - Replaced hard-coded OpenAI client calls with a more general `model_name` + `model_kwargs` interface.  
  - Integrated `litellm.completion` for provider-agnostic completions.  
  - Removed redundant OpenAI-specific logic and environment variable handling.

- **Documentation updates**  
  - Clarified that LLM-based primitives default to GPT-4 but can be swapped for any supported model.  
  - Updated schema and value matching docs accordingly.  

- **Dependencies**  
  - Added `litellm` to `requirements.txt`.  
  - Cleaned up unused OpenAI test setup.  

- **Tests**  
  - Simplified matcher factory tests by removing OpenAI-specific API key mock.

## Motivation

This change makes it easier for users to:
- Plug in open-source or alternative LLMs (e.g., LLaMA, Gemini).  
- Configure model parameters without modifying core code.  