### PR TITLE
chore: Add a version constraint to transformers library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ polyfuzz
 pandas
 valentine>0.2.0
 torch
-transformers
+transformers<4.57.0
 tqdm
 scikit-learn
 flair[word-embeddings]>=0.14.0


### PR DESCRIPTION
Add a version constraint to `transformers` to maintain compatibility with Python 3.9.  

The latest `transformers` release uses the `int | None` syntax (PEP 604), which is not supported in Python 3.9. Since Python 3.9 will continue to receive support until **October 30, 2025**, this version constraint ensures our code remains compatible.  

After that date, we plan to drop Python 3.9 support and remove this constraint.
