### PR TITLE
chore(api): make panel optional and clean up visualization dependencies

### DIFF
--- a/bdikit/api.py
+++ b/bdikit/api.py
@@ -3,7 +3,6 @@ import logging
 import warnings
 import itertools
 import pandas as pd
-import panel as pn
 from collections import defaultdict
 
 from bdikit.schema_matching.base import (
@@ -52,8 +51,6 @@ from bdikit.matching_evaluation.schema_matching import (
 from bdikit.matching_evaluation.value_matching import (
     evaluate_match as evaluate_value_match,
 )
-
-pn.extension("tabulator")
 
 logger = logging.getLogger(__name__)
 
@@ -604,6 +601,18 @@ def view_value_matches(
         edit (bool, optional): Whether or not to edit the values within the DataFrame. Editable mode works only in Jupyter notebooks.
     """
 
+    if edit:
+        try:
+            import panel as pn
+
+            pn.extension("tabulator")
+        except ImportError:
+            warnings.warn(
+                "The 'panel' library is required for editing the matches. Please install it with 'pip install panel' and 'pip install jupyter_bokeh'."
+                "Displaying non-editable matches instead."
+            )
+            edit = False
+
     def regular_display():
         if isinstance(matches, pd.DataFrame):
             print(matches)
@@ -617,7 +626,9 @@ def view_value_matches(
         from IPython import get_ipython
 
         shell = get_ipython().__class__.__name__
-        if shell != "ZMQInteractiveShell":
+
+        # If not in a Jupyter notebook environment, use regular display
+        if shell not in ("ZMQInteractiveShell", "Shell"):
             regular_display()
             return
     except ImportError:

--- a/bdikit/api.py
+++ b/bdikit/api.py
@@ -603,12 +603,13 @@ def view_value_matches(
 
     if edit:
         try:
+            warnings.filterwarnings("ignore", message=".*jupyter_bokeh.*")
             import panel as pn
 
             pn.extension("tabulator")
         except ImportError:
             warnings.warn(
-                "The 'panel' library is required for editing the matches. Please install it with 'pip install panel' and 'pip install jupyter_bokeh'."
+                "The 'panel' library is required for editing the matches. Please install it with 'pip install panel'."
                 "Displaying non-editable matches instead."
             )
             edit = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ scikit-learn
 flair[word-embeddings]>=0.14.0
 requests
 scipy
-matplotlib<3.9
 nltk>=3.9.1
 magneto-python
 json-repair

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ flair[word-embeddings]>=0.14.0
 requests
 scipy
 matplotlib<3.9
-panel!=1.4.3
 nltk>=3.9.1
 magneto-python
 json-repair

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 polyfuzz
 gensim>=4.3.3
 pandas
-valentine>=0.5.0
+valentine==0.5.0
 sentence_transformers<=5.3.0
 torch
 transformers<5.0.0


### PR DESCRIPTION
This PR improves dependency handling and notebook compatibility in the API utilities by making `panel` an optional dependency and cleaning up the package requirements.

### Changes

- Removed the global `panel` import and initialization from `bdikit/api.py`
- Added conditional `panel` imports only when editable mode is enabled in `view_value_matches`
- Added graceful fallback behavior when `panel` is not installed
- Suppressed unnecessary `jupyter_bokeh` warnings during editable visualization
- Improved environment detection for notebook execution
- Pinned `valentine` to version `0.5.0`
- Removed unnecessary dependencies:
  - `matplotlib`
  - `panel`

## Motivation

Previously, importing `bdikit.api` required `panel` to be installed even when interactive editing features were not used. This caused unnecessary dependency requirements and import issues in lightweight environments.

With this change:
- `panel` becomes an optional dependency
- non-interactive functionality works without additional visualization packages
- users receive a clear warning and fallback behavior when editable mode is requested without `panel`